### PR TITLE
fix: prevent pll home redirects; fix: prevent WP from guessing 404 links

### DIFF
--- a/classes/traits/translateable.php
+++ b/classes/traits/translateable.php
@@ -40,7 +40,7 @@ trait Translateable {
 
         $lang_code_from_cookie = zume_get_language_cookie();
 
-        if ( empty( $lang_code_from_cookie ) ) {
+        if ( empty( $lang_code_from_cookie ) || $lang_code_from_cookie !== $lang_code ) {
             zume_set_language_cookie( $lang_code );
         }
 

--- a/zume-training-system.php
+++ b/zume-training-system.php
@@ -75,8 +75,30 @@ add_filter( 'dt_plugins', function ( $plugins ){
     ];
     return $plugins;
 });
-/* This needs to be added before plugins_loaded fires and this filter is applied */
-add_filter( 'pll_redirect_home', '__return_false', 1000 );
+/*
+  This needs to be added before plugins_loaded fires and this filter is applied
+*/
+add_filter( 'pll_redirect_home', 'zume_pll_redirect_home', 1000 );
+function zume_pll_redirect_home( $redirect ) {
+    /*
+      Attempt to fix PLL trying to redirect to homepage in language from cookie when hitting the root url.
+      We also need to set the cookie to (default) english as this is skipped when not redirecting home
+      PROBLEM: this sets the cookie correctly but fails to setup the pll_current_language correctly
+    */
+    /* Copying same PLL options from polylang/frontend/choose-lang.php maybe_setcookie() */
+/*     $args = [
+        'domain' => false,
+        'samesite' => 'Lax',
+    ];
+
+    PLL_Cookie::set( pll_default_language( 'slug' ), $args );
+  */
+
+    /* An alternate solution is to just redirect to default language when hitting root url */
+    $my_redirect = home_url( pll_default_language( 'slug' ) );
+
+    return $my_redirect;
+}
 
 class Zume_Training {
     private static $_instance = null;

--- a/zume-training-system.php
+++ b/zume-training-system.php
@@ -75,7 +75,8 @@ add_filter( 'dt_plugins', function ( $plugins ){
     ];
     return $plugins;
 });
-
+/* This needs to be added before plugins_loaded fires and this filter is applied */
+add_filter( 'pll_redirect_home', '__return_false', 1000 );
 
 class Zume_Training {
     private static $_instance = null;
@@ -135,7 +136,7 @@ class Zume_Training {
         add_filter( 'email_change_email', [ $this, 'filter_email_change_email' ], 10, 1 );
         add_action( 'dt_create_users_corresponding_contact', [ $this, 'dt_create_users_corresponding_contact' ], 10, 2 );
         add_action( 'dt_post_updated', [ $this, 'update_coaching_contact' ], 10, 5 );
-        add_filter( 'pll_redirect_home', '__return_false' );
+        add_filter( 'pre_redirect_guess_404_permalink', '__return_false' );
 
         /* Ensure that Login is enabled and settings set to the correct values */
         $fields = [


### PR DESCRIPTION

WP was redirecting /training --> /am/training-am as all magic links 404 and WP templating system was finding the amharic training page as the best match