### PR TITLE
fix: move i18n call up to 'init' hook

### DIFF
--- a/utilities/apis/cta-api.php
+++ b/utilities/apis/cta-api.php
@@ -59,11 +59,6 @@ class Zume_System_CTA_API
             return new WP_Error( 'no_user_id', 'Missing parames user_id or language', array( 'status' => 400 ) );
         }
 
-        global $zume_languages_by_code;
-        $language = $zume_languages_by_code[$params['language']];
-
-        switch_to_locale( $language['locale'] );
-
         return self::_get_ctas( $params['user_id'] );
     }
     public static function _get_ctas( $user_id, $log = null ) : array


### PR DESCRIPTION
this ensures that the translations are loaded before all calls, API and frontend

resolves #303 